### PR TITLE
Let froyo work on stable rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+script:
+  - cargo build --verbose
+  - |
+    [ $TRAVIS_RUST_VERSION != nightly ] ||
+    cargo build --verbose --features clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
  "crc 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "custom_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "devicemapper 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "devicemapper 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "newtype_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -123,15 +123,12 @@ dependencies = [
 
 [[package]]
 name = "devicemapper"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -295,14 +292,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quasi_macros"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quasi_codegen 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "quine-mc_cluskey"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,7 +348,6 @@ dependencies = [
  "aster 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quasi 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quasi_codegen 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quasi_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_codegen_internals 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_syntax 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -382,14 +370,6 @@ dependencies = [
  "itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde_macros"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde_codegen 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,8 +13,8 @@ dependencies = [
  "newtype_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -29,6 +29,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "aster"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syntex_syntax 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "bitflags"
@@ -38,6 +41,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bitflags"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -148,6 +156,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libc"
 version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -265,6 +278,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "quasi"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syntex_errors 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "quasi_codegen"
@@ -272,6 +289,9 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aster 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_errors 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -338,14 +358,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aster 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quasi 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi_codegen 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quasi_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_codegen_internals 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_codegen_internals"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syntex_errors 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_json"
@@ -369,6 +396,51 @@ dependencies = [
 name = "strsim"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syntex"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syntex_errors 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syntex_errors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_pos 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syntex_pos"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syntex_syntax"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_errors 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_pos 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "term"
@@ -400,6 +472,11 @@ dependencies = [
 [[package]]
 name = "unicode-normalization"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,13 @@
 name = "froyo"
 version = "0.1.0"
 authors = ["Andy Grover <agrover@redhat.com>"]
+build = "build.rs"
+
+[build-dependencies]
+serde_codegen = "0.7"
 
 [dependencies]
-clippy = "0"
+clippy = { version = "0", optional = true }
 devicemapper = "0.3.0"
 clap = "1"
 nix = "0"
@@ -12,9 +16,8 @@ crc = "1"
 byteorder = "0.3.13"
 uuid = "0.1.18"
 time = "0.1"
-serde = "*"
-serde_json = "*"
-serde_macros = "0"
+serde = "0.7"
+serde_json = "0.7"
 custom_derive = "0.1"
 bytesize = "0.1.1"
 dbus = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ serde_codegen = "0.7"
 
 [dependencies]
 clippy = { version = "0", optional = true }
-devicemapper = "0.3.0"
+devicemapper = "0.4.0"
 clap = "1"
 nix = "0"
 crc = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,4 @@ custom_derive = "0.1"
 bytesize = "0.1.1"
 dbus = "0.3"
 term = "0.4"
-
-[dependencies.newtype_derive]
-version = "0.1"
-default-features = false
-features = ["std-unstable"]
+newtype_derive = "0.1"

--- a/README.md
+++ b/README.md
@@ -18,15 +18,6 @@ IRC: `#froyo` on irc.freenode.org
 
 Mailing list: `froyo@lists.fedorahosted.org`
 
-## Development notes
-
-Currently requires using [Rust nightly compiler](https://doc.rust-lang.org/book/nightly-rust.html).
-
-The last verified working nightly snapshot was 2016-07-18. If using
-Multirust, run `multirust override nightly-2016-07-18` in the `froyo`
-directory to use this snapshot for Froyo. If using Rustup, see its
-docs for how to accomplish the same thing.
-
 ## Trying it out (Caution highly recommended, may eat data!)
 
 1. Compile Froyo

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+extern crate serde_codegen;
+
+use std::env;
+use std::path::Path;
+
+fn main() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+
+    let src = Path::new("src/serialize.rs.in");
+    let dst = Path::new(&out_dir).join("serialize.rs");
+
+    serde_codegen::expand(&src, &dst).unwrap();
+}

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -22,7 +22,7 @@ use byteorder::{LittleEndian, ByteOrder};
 use uuid::Uuid;
 use bytesize::ByteSize;
 
-use types::{Sectors, SectorOffset, FroyoResult, FroyoError};
+use types::{Sectors, SumSectors, SectorOffset, FroyoResult, FroyoError};
 use consts::*;
 use util::blkdev_size;
 use dmdevice::DmDevice;
@@ -421,7 +421,7 @@ impl BlockDevs {
 
     // Unused (non-redundant) space left on blockdevs
     pub fn unused_space(&self) -> Sectors {
-        self.avail_areas().iter().map(|&(_, _, len)| len).sum::<Sectors>()
+        self.avail_areas().iter().map(|&(_, _, len)| len).sum_sectors()
     }
 
     pub fn avail_areas(&self) -> Vec<(Rc<RefCell<BlockDev>>, SectorOffset, Sectors)> {
@@ -567,10 +567,10 @@ impl LinearDev {
     }
 
     pub fn metadata_length(&self) -> Sectors {
-        self.meta_segments.iter().map(|x| x.length).sum()
+        self.meta_segments.iter().map(|x| x.length).sum_sectors()
     }
 
     pub fn data_length(&self) -> Sectors {
-        self.data_segments.iter().map(|x| x.length).sum()
+        self.data_segments.iter().map(|x| x.length).sum_sectors()
     }
 }

--- a/src/blockdev.rs
+++ b/src/blockdev.rs
@@ -27,18 +27,14 @@ use consts::*;
 use util::blkdev_size;
 use dmdevice::DmDevice;
 
+pub use serialize::{BlockDevSave, LinearSegment, LinearDevSave};
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct MDA {
     pub last_updated: Timespec,
     length: u32,
     crc: u32,
     offset: SectorOffset,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlockDevSave {
-    pub path: PathBuf,
-    pub sectors: Sectors,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -465,12 +461,6 @@ impl BlockDevs {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
-pub struct LinearSegment {
-    pub start: SectorOffset,
-    pub length: Sectors,
-}
-
 impl LinearSegment {
     pub fn new(start: SectorOffset, length: Sectors) -> LinearSegment {
         LinearSegment {
@@ -478,13 +468,6 @@ impl LinearSegment {
             length: length,
         }
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct LinearDevSave {
-    pub meta_segments: Vec<LinearSegment>,
-    pub data_segments: Vec<LinearSegment>,
-    pub parent: String,
 }
 
 // A LinearDev contains two mappings within a single blockdev. This is

--- a/src/froyo.rs
+++ b/src/froyo.rs
@@ -18,29 +18,19 @@ use serde_json;
 use time;
 use bytesize::ByteSize;
 
-use blockdev::{BlockDev, BlockDevs, BlockDevSave, BlockMember};
+use blockdev::{BlockDev, BlockDevs, BlockMember};
 use blockdev::LinearSegment;
-use raid::{RaidDevs, RaidDevSave, RaidSegment, RaidLinearDev, RaidStatus,
+use raid::{RaidDevs, RaidSegment, RaidLinearDev, RaidStatus,
            RaidAction, RaidMember, RaidLayer};
-use thin::{ThinPoolDev, ThinPoolDevSave, ThinPoolStatus, ThinPoolWorkingStatus};
-use thin::{ThinDev, ThinDevSave, ThinStatus};
-use mirror::{MirrorDev, TempDev, TempDevSave, TempLayer};
+use thin::{ThinPoolDev, ThinPoolStatus, ThinPoolWorkingStatus};
+use thin::{ThinDev, ThinStatus};
+use mirror::{MirrorDev, TempDev, TempLayer};
 use types::{Sectors, SectorOffset, DataBlocks, FroyoError, FroyoResult, InternalError};
 use dbus_api::DbusContext;
 use util::short_id;
 use consts::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FroyoSave {
-    pub name: String,
-    pub id: String,
-    pub block_devs: BTreeMap<String, BlockDevSave>,
-    pub raid_devs: BTreeMap<String, RaidDevSave>,
-    pub thin_pool_dev: ThinPoolDevSave,
-    pub thin_devs: Vec<ThinDevSave>,
-    #[serde(skip_serializing_if="Option::is_none")]
-    pub temp_dev: Option<TempDevSave>,
-}
+pub use serialize::FroyoSave;
 
 #[derive(Debug, Clone)]
 pub struct Froyo<'a> {

--- a/src/froyo.rs
+++ b/src/froyo.rs
@@ -25,7 +25,7 @@ use raid::{RaidDevs, RaidSegment, RaidLinearDev, RaidStatus,
 use thin::{ThinPoolDev, ThinPoolStatus, ThinPoolWorkingStatus};
 use thin::{ThinDev, ThinStatus};
 use mirror::{MirrorDev, TempDev, TempLayer};
-use types::{Sectors, SectorOffset, DataBlocks, FroyoError, FroyoResult, InternalError};
+use types::{Sectors, SumSectors, SectorOffset, DataBlocks, FroyoError, FroyoResult, InternalError};
 use dbus_api::DbusContext;
 use util::short_id;
 use consts::*;
@@ -1082,7 +1082,7 @@ impl<'a> Froyo<'a> {
                 let sz = (members_present - REDUNDANCY) * *per_member_data_size as usize;
                 Sectors(sz as u64)
             })
-            .sum::<Sectors>();
+            .sum_sectors();
 
         if self.thin_pool_dev.used_sectors() > reshaped_tot_size {
             dbgp!("can't reshape, too much data for reshaped froyodev");
@@ -1254,7 +1254,7 @@ impl<'a> Froyo<'a> {
             .collect::<Vec<_>>();
         let spc_needed = raid_segs.iter()
             .map(|&(_, ls)| ls.length)
-            .sum::<Sectors>();
+            .sum_sectors();
 
         let scratch_areas = try!(
             self.block_devs.get_linear_segments(spc_needed)

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#![feature(iter_arith_traits)]
-
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 #![cfg_attr(not(feature = "clippy"), allow(unknown_lints))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#![feature(custom_derive, iter_arith_traits, custom_attribute, plugin, const_fn)]
-#![plugin(serde_macros)]
-#![plugin(clippy)]
+#![feature(iter_arith_traits)]
+
+#![cfg_attr(feature = "clippy", feature(plugin))]
+#![cfg_attr(feature = "clippy", plugin(clippy))]
+#![cfg_attr(not(feature = "clippy"), allow(unknown_lints))]
 
 #![allow(match_same_arms)] // we seem to have instances where same arms are good
 #![allow(if_not_else)]
@@ -50,6 +52,10 @@ mod dmdevice;
 mod thin;
 mod util;
 mod dbus_api;
+
+mod serialize {
+    include!(concat!(env!("OUT_DIR"), "/serialize.rs"));
+}
 
 use std::io::Write;
 use std::error::Error;

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 use devicemapper::DM;
 
 use froyo::FroyoSave;
-use types::{Sectors, SectorOffset, FroyoResult, FroyoError, InternalError};
+use types::{Sectors, SumSectors, SectorOffset, FroyoResult, FroyoError, InternalError};
 use consts::*;
 use blockdev::{LinearSegment, BlockDev, BlockDevs};
 use dmdevice::DmDevice;
@@ -197,7 +197,7 @@ impl TempDev {
     }
 
     pub fn length(&self) -> Sectors {
-        self.segments.iter().map(|&(_, x)| x.length).sum()
+        self.segments.iter().map(|&(_, x)| x.length).sum_sectors()
     }
 
     pub fn to_save(&self) -> TempDevSave {

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -16,6 +16,8 @@ use blockdev::{LinearSegment, BlockDev, BlockDevs};
 use dmdevice::DmDevice;
 use raid::{RaidDev, RaidLinearDev};
 
+pub use serialize::{TempDevSegmentSave, TempDevSave};
+
 #[derive(Debug, Clone)]
 pub struct MirrorDev {
     pub mirror: DmDevice,
@@ -123,19 +125,6 @@ impl TempLayer {
             TempLayer::Raid(ref rd) => rd.borrow().id.to_owned(),
         }
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TempDevSegmentSave {
-    pub parent: String,
-    pub start: SectorOffset,
-    pub length: Sectors,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TempDevSave {
-    pub id: String,
-    pub segments: Vec<TempDevSegmentSave>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/raid.rs
+++ b/src/raid.rs
@@ -22,14 +22,7 @@ use dmdevice::DmDevice;
 use mirror::{TempDev};
 use util::align_to;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RaidDevSave {
-    pub stripe_sectors: Sectors,
-    pub region_sectors: Sectors,
-    pub length: Sectors,
-    pub member_count: usize,
-    pub members: BTreeMap<String, LinearDevSave>,
-}
+pub use serialize::{RaidDevSave, RaidSegmentSave, RaidLinearDevSave};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct RaidDev {
@@ -799,13 +792,6 @@ impl RaidDevs {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RaidSegmentSave {
-    pub start: SectorOffset,
-    pub length: Sectors,
-    pub parent: String,  // RaidDev id
-}
-
 // A RaidSegment will almost always be on a RaidDev, unless we're
 // reshaping and we had to temporarily copy it to a temp area.
 #[derive(Debug, Clone)]
@@ -902,12 +888,6 @@ impl Drop for RaidSegment {
             RaidLayer::Temp(_) => {},
         };
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RaidLinearDevSave {
-    pub id: String,
-    pub segments: Vec<RaidSegmentSave>,
 }
 
 #[derive(Debug)]

--- a/src/raid.rs
+++ b/src/raid.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 use devicemapper::DM;
 
 use froyo::FroyoSave;
-use types::{Sectors, SectorOffset, FroyoError, FroyoResult, InternalError};
+use types::{Sectors, SumSectors, SectorOffset, FroyoError, FroyoResult, InternalError};
 use blockdev::{LinearDev, LinearDevSave, BlockDev, LinearSegment, BlockDevs, BlockMember};
 use consts::*;
 use dmdevice::DmDevice;
@@ -237,7 +237,7 @@ impl RaidDev {
     fn avail_sectors(&self) -> Sectors {
         self.avail_areas().into_iter()
             .map(|(_, len)| len)
-            .sum()
+            .sum_sectors()
     }
 
     // Is this raiddev a good one to maybe put more stuff on?
@@ -743,7 +743,7 @@ impl RaidDevs {
             .map(|(_, rd)| {
                 rd.borrow().used_areas().into_iter()
                     .map(|(_, len)| len)
-                    .sum::<Sectors>()
+                    .sum_sectors()
             })
             .max().unwrap_or_else(|| Sectors(0))
     }
@@ -751,13 +751,13 @@ impl RaidDevs {
     pub fn avail_space(&self) -> Sectors {
         self.raids.values()
             .map(|rd| rd.borrow().avail_sectors())
-            .sum::<Sectors>()
+            .sum_sectors()
     }
 
     pub fn total_space(&self) -> Sectors {
         self.raids.values()
             .map(|rd| rd.borrow().length)
-            .sum::<Sectors>()
+            .sum_sectors()
     }
 
     pub fn add_new_block_device(&mut self, froyo_id: &str, blockdev: &Rc<RefCell<BlockDev>>)
@@ -950,7 +950,7 @@ impl RaidLinearDev {
     }
 
     pub fn length(&self) -> Sectors {
-        self.segments.iter().map(|x| x.length).sum()
+        self.segments.iter().map(|x| x.length).sum_sectors()
     }
 
     pub fn extend(&mut self, segs: Vec<RaidSegment>)

--- a/src/serialize.rs.in
+++ b/src/serialize.rs.in
@@ -1,0 +1,85 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use types::{Sectors, SectorOffset, DataBlocks};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockDevSave {
+    pub path: PathBuf,
+    pub sectors: Sectors,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct LinearSegment {
+    pub start: SectorOffset,
+    pub length: Sectors,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LinearDevSave {
+    pub meta_segments: Vec<LinearSegment>,
+    pub data_segments: Vec<LinearSegment>,
+    pub parent: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FroyoSave {
+    pub name: String,
+    pub id: String,
+    pub block_devs: BTreeMap<String, BlockDevSave>,
+    pub raid_devs: BTreeMap<String, RaidDevSave>,
+    pub thin_pool_dev: ThinPoolDevSave,
+    pub thin_devs: Vec<ThinDevSave>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub temp_dev: Option<TempDevSave>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TempDevSegmentSave {
+    pub parent: String,
+    pub start: SectorOffset,
+    pub length: Sectors,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TempDevSave {
+    pub id: String,
+    pub segments: Vec<TempDevSegmentSave>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RaidDevSave {
+    pub stripe_sectors: Sectors,
+    pub region_sectors: Sectors,
+    pub length: Sectors,
+    pub member_count: usize,
+    pub members: BTreeMap<String, LinearDevSave>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RaidSegmentSave {
+    pub start: SectorOffset,
+    pub length: Sectors,
+    pub parent: String,  // RaidDev id
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RaidLinearDevSave {
+    pub id: String,
+    pub segments: Vec<RaidSegmentSave>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThinPoolDevSave {
+    pub data_block_size: Sectors,
+    pub low_water_blocks: DataBlocks,
+    pub meta_dev: RaidLinearDevSave,
+    pub data_dev: RaidLinearDevSave,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThinDevSave {
+    pub name: String,
+    pub thin_number: u32,
+    pub size: Sectors,
+}

--- a/src/thin.rs
+++ b/src/thin.rs
@@ -15,17 +15,11 @@ use nix::sys::stat::{mknod, umask, Mode, S_IFBLK, S_IRUSR, S_IWUSR, S_IRGRP, S_I
 use nix::errno::EEXIST;
 
 use types::{Sectors, DataBlocks, FroyoError, FroyoResult, InternalError};
-use raid::{RaidSegment, RaidLinearDev, RaidLinearDevSave};
+use raid::{RaidSegment, RaidLinearDev};
 use dmdevice::DmDevice;
 use consts::*;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ThinPoolDevSave {
-    pub data_block_size: Sectors,
-    pub low_water_blocks: DataBlocks,
-    pub meta_dev: RaidLinearDevSave,
-    pub data_dev: RaidLinearDevSave,
-}
+pub use serialize::{ThinPoolDevSave, ThinDevSave};
 
 #[derive(Debug, Clone)]
 pub struct ThinPoolDev {
@@ -245,13 +239,6 @@ impl ThinPoolDev {
     pub fn used_sectors(&self) -> Sectors {
         self.meta_dev.borrow().length() + self.data_dev.borrow().length()
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ThinDevSave {
-    pub name: String,
-    pub thin_number: u32,
-    pub size: Sectors,
 }
 
 #[derive(Debug, Clone)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,6 +6,7 @@ use std::io;
 use std::fmt;
 use std::error::Error;
 use std::borrow::Cow;
+use std::ops::Add;
 
 use serde;
 use serde_json;
@@ -23,9 +24,25 @@ pub type FroyoResult<T> = Result<T, FroyoError>;
 custom_derive! {
     #[derive(NewtypeFrom, NewtypeAdd, NewtypeSub, NewtypeDeref,
              NewtypeBitAnd, NewtypeNot, NewtypeDiv, NewtypeRem,
-             NewtypeMul, NewtypeSum,
+             NewtypeMul,
              Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
     pub struct Sectors(pub u64);
+}
+
+// `SumSectors` can be discarded once `std::iter::Sum` is stable.
+pub trait SumSectors: Iterator
+where Sectors: Add<Self::Item, Output=Sectors>
+{
+    fn sum_sectors(self) -> Sectors
+        where Self: Sized
+    {
+        self.fold(Sectors(0), Add::add)
+    }
+}
+
+impl<T: Iterator> SumSectors for T
+where Sectors: Add<T::Item, Output=Sectors>
+{
 }
 
 impl serde::Serialize for Sectors {


### PR DESCRIPTION
- Make clippy optional; use --features clippy to enable it.
- Convert serialization to `serde_codegen` in a build script.
- Avoid `std::iter::Sum` until it's stabilized.
- Add a Travis CI script testing stable, nightly, and beta.
